### PR TITLE
API Version update to allow repackaging for ICU Local Format update compliance

### DIFF
--- a/aura/streaming/streaming.cmp-meta.xml
+++ b/aura/streaming/streaming.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>43.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/aura/streamingEvent/streamingEvent.evt-meta.xml
+++ b/aura/streamingEvent/streamingEvent.evt-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>43.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/aura/userView/userView.cmp-meta.xml
+++ b/aura/userView/userView.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>43.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/aura/whosViewing/whosViewing.cmp-meta.xml
+++ b/aura/whosViewing/whosViewing.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>43.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/classes/whosViewingController.cls-meta.xml
+++ b/classes/whosViewingController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>43.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/classes/whosViewingTest.cls-meta.xml
+++ b/classes/whosViewingTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>43.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/package.xml
+++ b/package.xml
@@ -93,5 +93,5 @@
         <members>cometd</members>
         <name>StaticResource</name>
     </types>
-    <version>44.0</version>
+    <version>64.0</version>
 </Package>


### PR DESCRIPTION
Update to the latest version of the API to allow for a package upgrade that will comply with the ICU local format update. Needs to be v45 or higher, updated to v64 (latest).